### PR TITLE
python file sharing - can be viewed, executed with pyodide, uploaded back 

### DIFF
--- a/components/files/FileList.tsx
+++ b/components/files/FileList.tsx
@@ -5,10 +5,13 @@ import { FileRow } from "./FileRow";
 import { Upload, Download } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { memo } from "react";
+import { FileItem } from "@/types/files";
 
-interface EmptyProps { icon: React.ReactNode; title: string; subtitle: string }
-
-// FileRow is already memoized in its own file
+interface EmptyProps {
+  icon: React.ReactNode;
+  title: string;
+  subtitle: string;
+}
 
 const EmptyState = ({ icon, title, subtitle }: EmptyProps) => {
   return (
@@ -18,64 +21,86 @@ const EmptyState = ({ icon, title, subtitle }: EmptyProps) => {
       <p className="text-xs mt-1">{subtitle}</p>
     </div>
   );
+};
+
+interface FileListProps {
+  onViewPyFile?: (file: FileItem) => void;
+  processingPyFileId?: string | null;
 }
 
-export const FileList = memo(() => {
-  const { sentFiles, receivedFiles } = useFileTransfer();
+export const FileList = memo(
+  ({ onViewPyFile, processingPyFileId }: FileListProps) => {
+    const { sentFiles, receivedFiles } = useFileTransfer();
 
-  return (
-    <Tabs defaultValue="sent" className="w-full">
-      <TabsList className="grid w-full grid-cols-2 mb-4 font-mono">
-        <TabsTrigger value="sent" className="flex items-center gap-2">
-          <Upload size={16} />
-          SENT_FILES
-        </TabsTrigger>
-        <TabsTrigger value="received" className="flex items-center gap-2">
-          <Download size={16} />
-          RECEIVED_FILES
-        </TabsTrigger>
-      </TabsList>
+    return (
+      <Tabs defaultValue="sent" className="w-full">
+        <TabsList className="grid w-full grid-cols-2 mb-4 font-mono">
+          <TabsTrigger value="sent" className="flex items-center gap-2">
+            <Upload size={16} />
+            SENT_FILES
+          </TabsTrigger>
+          <TabsTrigger value="received" className="flex items-center gap-2">
+            <Download size={16} />
+            RECEIVED_FILES
+          </TabsTrigger>
+        </TabsList>
 
-      <TabsContent value="sent">
-        <Card>
-          <CardContent className="p-6 bg-card">
-            <div className="h-[250px] overflow-y-auto overflow-x-hidden space-y-4">
-              {sentFiles.length ? (
-                sentFiles.map((f) => (
-                  <FileRow
-                    key={f.id}
-                    file={f}
+        <TabsContent value="sent">
+          <Card>
+            <CardContent className="p-6 bg-card">
+              <div className="h-[250px] overflow-y-auto overflow-x-hidden space-y-4">
+                {sentFiles.length ? (
+                  sentFiles.map((f) => (
+                    <FileRow
+                      key={f.id}
+                      file={f}
+                      // Pyodide typically runs on received files, but props are available
+                      // onViewPyFile={onViewPyFile}
+                      // isProcessingPyView={processingPyFileId === f.id.toString()}
+                    />
+                  ))
+                ) : (
+                  <EmptyState
+                    icon={<Upload size={24} />}
+                    title="No files sent"
+                    subtitle="Upload files to see them here"
                   />
-                ))
-              ) : (
-                <EmptyState icon={<Upload size={24} />} title="No files sent" subtitle="Upload files to see them here" />
-              )}
-            </div>
-          </CardContent>
-        </Card>
-      </TabsContent>
+                )}
+              </div>
+            </CardContent>
+          </Card>
+        </TabsContent>
 
-      <TabsContent value="received">
-        <Card>
-          <CardContent className="p-6 bg-card">
-            <div className="h-[250px] overflow-y-auto overflow-x-hidden space-y-4">
-              {receivedFiles.length ? (
-                receivedFiles.map((f) => (
-                  <FileRow
-                    key={f.id}
-                    file={f}
+        <TabsContent value="received">
+          <Card>
+            <CardContent className="p-6 bg-card">
+              <div className="h-[250px] overflow-y-auto overflow-x-hidden space-y-4">
+                {receivedFiles.length ? (
+                  receivedFiles.map((f) => (
+                    <FileRow
+                      key={f.id}
+                      file={f}
+                      onViewPyFile={onViewPyFile}
+                      isProcessingPyView={
+                        processingPyFileId === f.id.toString()
+                      }
+                    />
+                  ))
+                ) : (
+                  <EmptyState
+                    icon={<Download size={24} />}
+                    title="No files received"
+                    subtitle="Incoming files will appear here"
                   />
-                ))
-              ) : (
-                <EmptyState icon={<Download size={24} />} title="No files received" subtitle="Incoming files will appear here" />
-              )}
-            </div>
-          </CardContent>
-        </Card>
-      </TabsContent>
-    </Tabs>
-  );
-});
+                )}
+              </div>
+            </CardContent>
+          </Card>
+        </TabsContent>
+      </Tabs>
+    );
+  }
+);
 
 // add FileList display name
 FileList.displayName = "FileList";

--- a/components/files/FileRow.tsx
+++ b/components/files/FileRow.tsx
@@ -1,40 +1,73 @@
 // components/files/FileRow.tsx
 import { Button } from "@/components/ui/button";
-import { Copy, Download, File, FileText, Image as ImageIcon } from "lucide-react";
+import {
+  Copy,
+  Download,
+  File,
+  FileText,
+  Image as ImageIcon,
+  Eye,
+  Loader2,
+} from "lucide-react";
 import { useFileTransfer } from "@/context/FileTransferContext";
 import EncryptionBadge from "./EncryptionBadge";
-
 import { FileItem } from "@/types/files";
 
 interface FileRowProps {
   file: FileItem;
+  onViewPyFile?: (file: FileItem) => void; // New prop
+  isProcessingPyView?: boolean; // New prop
 }
 
-const getFileIcon = (type: string) => {
+const getFileIcon = (type: string, name: string) => {
+  if (name.endsWith(".py"))
+    return (
+      <FileText
+        size={18}
+        className="text-green-500 opacity-80 hover:opacity-100"
+      />
+    );
   if (type.startsWith("image")) return <ImageIcon size={18} />;
   if (type.includes("pdf")) return <FileText size={18} />;
   return <File size={18} />;
 };
 
-export const FileRow = ({ file }: FileRowProps) => {
-  const { copyFileCid, downloadFile, copySuccess } = useFileTransfer();
+export const FileRow = ({
+  file,
+  onViewPyFile,
+  isProcessingPyView,
+}: FileRowProps) => {
+  // Assuming useFileTransfer will be updated to expose decryptionInProgress if needed for download button
+  const { copyFileCid, downloadFile, copySuccess /*, decryptionInProgress */ } =
+    useFileTransfer();
+
+  const handleViewClick = () => {
+    if (onViewPyFile && file.name.endsWith(".py")) {
+      onViewPyFile(file);
+    }
+  };
+
+  // Example: if decryptionInProgress comes from useFileTransfer for download button
+  // const isDownloadingAndDecrypting = decryptionInProgress && decryptionInProgress[file.fileId?.toString() ?? ""];
 
   return (
     <div className="flex items-center justify-between p-2 bg-muted rounded-md border border-border hover:bg-accent/40 transition-colors">
       <div className="flex items-center gap-3 min-w-0 flex-1 overflow-hidden">
         <div className="p-1 rounded bg-card text-primary border border-border hover:border-primary/20 hover:bg-accent/50 transition-colors flex-shrink-0">
-          {getFileIcon(file.type)}
+          {getFileIcon(file.type, file.name)}
         </div>
         <div className="min-w-0 flex-1 overflow-hidden font-medium text-sm font-mono truncate">
-          <p className="truncate font-mono text-sm">
-            {file.name}
-          </p>
+          <p className="truncate font-mono text-sm">{file.name}</p>
           <p className="text-xs text-muted-foreground truncate font-mono">
             {file.size.toFixed(2)} MB • {file.timestamp}
           </p>
           {file.fileId && (
-            <p className="text-xs text-primary/70 font-mono truncate" title={file.fileId}>
-              CID: {file.fileId.substring(0, 8)}...{file.fileId.substring(file.fileId.length - 6)}
+            <p
+              className="text-xs text-primary/70 font-mono truncate"
+              title={file.fileId}
+            >
+              CID: {file.fileId.substring(0, 8)}...
+              {file.fileId.substring(file.fileId.length - 6)}
             </p>
           )}
           {!file.fileId && (
@@ -42,29 +75,63 @@ export const FileRow = ({ file }: FileRowProps) => {
               CID: Not available
             </p>
           )}
-          {file.isEncrypted && <EncryptionBadge accessCondition={file.accessCondition} />}
+          {file.isEncrypted && (
+            <EncryptionBadge accessCondition={file.accessCondition} />
+          )}
         </div>
       </div>
       <div className="flex items-center gap-1 flex-shrink-0 ml-2">
+        {file.name.endsWith(".py") && onViewPyFile && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleViewClick}
+            className="h-7 w-7 p-0"
+            disabled={!file.fileId || isProcessingPyView}
+            title="View & Run Python Script"
+          >
+            {isProcessingPyView ? (
+              <Loader2 size={14} className="animate-spin" />
+            ) : (
+              <Eye size={14} />
+            )}
+          </Button>
+        )}
         <Button
           variant="ghost"
           size="sm"
           onClick={() => copyFileCid(file.id.toString())}
           className="h-7 w-7 p-0"
           disabled={!file.fileId}
+          title="Copy CID"
         >
-          {copySuccess === file.id.toString() ? <span className="text-green-500">✓</span> : <Copy size={14} />}
+          {copySuccess === file.id.toString() ? (
+            <span className="text-green-500">✓</span>
+          ) : (
+            <Copy size={14} />
+          )}
         </Button>
         <Button
           variant="ghost"
           size="sm"
           onClick={() => downloadFile(file.id.toString())}
           className="h-7 w-7 p-0"
-          disabled={!file.fileId}
+          // Simpler disable: if it's a .py file being viewed (and might be encrypted), don't allow simultaneous download
+          // A more robust solution would involve checking `decryptionInProgress` from context for this specific file.
+          disabled={
+            !file.fileId ||
+            (file.name.endsWith(".py") &&
+              file.isEncrypted &&
+              isProcessingPyView)
+          }
+          title="Download File"
         >
+          {/* If using decryptionInProgress from context for download:
+          {isDownloadingAndDecrypting ? <Loader2 size={14} className="animate-spin" /> : <Download size={14} />}
+          For now, no separate loader for download button here unless context is updated */}
           <Download size={14} />
         </Button>
       </div>
     </div>
   );
-}
+};

--- a/components/pyodide/PyodideRunnerModal.tsx
+++ b/components/pyodide/PyodideRunnerModal.tsx
@@ -1,0 +1,479 @@
+// components/pyodide/PyodideRunnerModal.tsx
+import React, { useState, useEffect, useRef, useCallback } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogClose,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { toast } from "sonner";
+import { FileItem } from "@/types/files";
+import { useFileTransfer } from "@/context/FileTransferContext";
+import { useFileEncryption } from "@/hooks/useFileEncryption";
+import { useCodexContext } from "@/context/CodexContext";
+import { Loader2 } from "lucide-react";
+import { usePyodide, PyodideFile } from "@/hooks/usePyodide"; // Import the new hook
+
+interface PyodideRunnerModalProps {
+  isOpen: boolean;
+  onOpenChange: (isOpen: boolean) => void;
+  pythonFile: FileItem | null;
+}
+
+export default function PyodideRunnerModal({
+  isOpen,
+  onOpenChange,
+  pythonFile,
+}: PyodideRunnerModalProps) {
+  const {
+    isPyodideReady,
+    pyodideLoadingMessage,
+    ensurePyodideLoaded,
+    loadFilesToFs,
+    setGlobalVariable,
+    runPythonAsync: runPyodideScript, // Renamed to avoid conflict
+    readFileFromFs,
+    listDirFs,
+  } = usePyodide();
+
+  const [pyFileContent, setPyFileContent] = useState("");
+  const [selectedDataFiles, setSelectedDataFiles] = useState<FileList | null>(
+    null
+  );
+  const dataFileInputRef = useRef<HTMLInputElement>(null);
+  const [pyodideOutput, setPyodideOutput] = useState<string[]>([]); // For UI display
+  const [isScriptRunning, setIsScriptRunning] = useState(false);
+  const [pyodideOutputFilePath, setPyodideOutputFilePath] = useState<
+    string | null
+  >(null);
+
+  const { sendFiles: sendOutputFiles, uploadingFiles } = useFileTransfer();
+  const { decryptBlob } = useFileEncryption();
+  const { downloadFile: codexDownloadFileContent, isCodexNodeActive } =
+    useCodexContext();
+
+  const outputFileNameGuess = pyodideOutputFilePath?.split("/").pop();
+  const isOutputUploading = outputFileNameGuess
+    ? Object.values(uploadingFiles).some((f) => f.name === outputFileNameGuess)
+    : false;
+  const outputUploadProgress = outputFileNameGuess
+    ? Object.values(uploadingFiles).find((f) => f.name === outputFileNameGuess)
+        ?.progress ?? 0
+    : 0;
+
+  // Effect to ensure Pyodide is loaded when the modal opens
+  useEffect(() => {
+    if (isOpen) {
+      ensurePyodideLoaded().catch((err) => {
+        // Error during Pyodide load is handled by the hook's state (pyodideLoadingMessage)
+        console.error("Modal: Pyodide failed to load via hook", err);
+        toast.error("Pyodide engine could not be loaded.");
+      });
+    }
+  }, [isOpen, ensurePyodideLoaded]);
+
+  // Effect to fetch Python script content
+  useEffect(() => {
+    if (!isOpen || !pythonFile || !pythonFile.fileId) {
+      setPyFileContent("");
+      return;
+    }
+    const fetchContent = async () => {
+      toast.info(`Fetching ${pythonFile.name}...`);
+      try {
+        const result = await codexDownloadFileContent(pythonFile.fileId!);
+        if (!result.success || !result.data) {
+          throw new Error(result.error || "Failed to download script.");
+        }
+        let blob = result.data;
+        if (pythonFile.isEncrypted) {
+          toast.info(`Decrypting ${pythonFile.name}...`);
+          const decryptResult = await decryptBlob(blob, {
+            fileType: "text/plain",
+            accessCondition: pythonFile.accessCondition,
+          });
+          if (!decryptResult.decryptedBlob) {
+            throw new Error(
+              decryptResult.error?.message || "Decryption failed."
+            );
+          }
+          blob = decryptResult.decryptedBlob;
+        }
+        const content = await blob.text();
+        setPyFileContent(content);
+        toast.success(`${pythonFile.name} content loaded.`);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : "Unknown error";
+        toast.error(`Error loading script: ${msg}`);
+        setPyFileContent(`# Error loading script: ${msg}`);
+      }
+    };
+    fetchContent();
+  }, [isOpen, pythonFile, codexDownloadFileContent, decryptBlob]);
+
+  const handleRunScript = useCallback(async () => {
+    if (!isPyodideReady) {
+      toast.error("Pyodide is not ready.");
+      return;
+    }
+    if (!pyFileContent) {
+      toast.error("No Python script content loaded.");
+      return;
+    }
+    if (!selectedDataFiles || selectedDataFiles.length === 0) {
+      toast.error("No data files selected to run the script on.");
+      return;
+    }
+
+    setIsScriptRunning(true);
+    setPyodideOutputFilePath(null);
+    const initialOutput = [
+      `Running script: ${pythonFile?.name || "script.py"}...`,
+    ];
+    setPyodideOutput(initialOutput); // Reset and set initial
+    toast.info(`Running script: ${pythonFile?.name || "script.py"}`);
+
+    try {
+      const currentOutput = [...initialOutput]; // Local array for batching updates to state
+      const appendOutput = (msg: string) => {
+        currentOutput.push(msg);
+        // Batch state updates slightly for performance if many rapid logs
+        // For now, direct update is fine for simplicity unless performance issues arise
+        setPyodideOutput([...currentOutput]);
+      };
+
+      appendOutput("Loading data files into Pyodide FS...");
+      const pyodideFilesToLoad: PyodideFile[] = [];
+      for (const file of Array.from(selectedDataFiles)) {
+        const arrayBuffer = await file.arrayBuffer();
+        pyodideFilesToLoad.push({
+          name: file.name,
+          content: new Uint8Array(arrayBuffer),
+        });
+      }
+      const loadedDataFilePaths = await loadFilesToFs(
+        pyodideFilesToLoad,
+        "/home"
+      );
+      loadedDataFilePaths.forEach((path, index) => {
+        appendOutput(`Loaded ${selectedDataFiles[index].name} to ${path}`);
+      });
+
+      const filesInPyodideHome = listDirFs("/home");
+      appendOutput(
+        `Current files in Pyodide's /home/ directory: ${filesInPyodideHome.join(
+          ", "
+        )}`
+      );
+
+      setGlobalVariable("SELECTED_DATA_FILES", loadedDataFilePaths);
+      appendOutput(
+        `Made selected file paths available to Python as SELECTED_DATA_FILES: ${loadedDataFilePaths.join(
+          ", "
+        )}`
+      );
+
+      appendOutput("Executing Python script...");
+      const result = await runPyodideScript(
+        pyFileContent,
+        (stdoutMsg) => appendOutput(`[stdout] ${stdoutMsg}`),
+        (stderrMsg) => appendOutput(`[stderr] ${stderrMsg}`)
+      );
+      appendOutput("Script execution finished.");
+      if (result !== undefined) {
+        appendOutput(`Result: ${String(result)}`);
+      }
+
+      // Output file detection (same logic as before, using listDirFs and readFileFromFs)
+      let detectedOutputPath: string | null = null;
+      const filesAfterRun = listDirFs("/home");
+      const potentialOutputFiles = filesAfterRun.filter((f) => {
+        const isInputFile = loadedDataFilePaths.some((inputPath) =>
+          inputPath.endsWith(f.replace(/\s+/g, "_"))
+        ); // Compare with sanitized names
+        return (
+          !isInputFile &&
+          (f.toLowerCase().includes("output") ||
+            f.toLowerCase().includes("summary") ||
+            f.toLowerCase().includes("result") ||
+            f.toLowerCase().endsWith(".txt") ||
+            f.toLowerCase().endsWith(".csv"))
+        );
+      });
+
+      const nonPyOutputFiles = potentialOutputFiles.filter(
+        (f) => !f.toLowerCase().endsWith(".py")
+      );
+      if (nonPyOutputFiles.length > 0) {
+        detectedOutputPath = `/home/${nonPyOutputFiles[0]}`;
+      } else if (potentialOutputFiles.length > 0) {
+        detectedOutputPath = `/home/${potentialOutputFiles[0]}`;
+      }
+
+      if (detectedOutputPath) {
+        appendOutput(`Output file detected: ${detectedOutputPath}`);
+        setPyodideOutputFilePath(detectedOutputPath);
+        try {
+          const outputContent = readFileFromFs(
+            detectedOutputPath,
+            "utf8"
+          ) as string; // Assuming text
+          appendOutput(`--- Content of ${detectedOutputPath} ---`);
+          appendOutput(
+            outputContent.substring(0, 2000) +
+              (outputContent.length > 2000
+                ? "\n... (content truncated) ..."
+                : "")
+          );
+          appendOutput(`--- End ---`);
+          toast.success(
+            `Script finished. Output file detected: ${detectedOutputPath
+              .split("/")
+              .pop()}`
+          );
+        } catch (readErr: Error | unknown) {
+          const errorMessage =
+            readErr instanceof Error ? readErr.message : String(readErr);
+          appendOutput(
+            `Could not read content of ${detectedOutputPath}: ${errorMessage}`
+          );
+          toast.info(
+            `Script finished. Output file detected but content could not be read: ${detectedOutputPath
+              .split("/")
+              .pop()}`
+          );
+        }
+      } else {
+        appendOutput(
+          `No clear output file detected in /home/. Check script logic if output was expected. Files in /home: ${filesAfterRun.join(
+            ", "
+          )}`
+        );
+        toast.info("Script finished. No new specific output file found.");
+      }
+    } catch (error) {
+      const errorMsg = error instanceof Error ? error.message : String(error);
+      setPyodideOutput((prev) => [...prev, `Execution Error: ${errorMsg}`]); // Ensure this still works if appendOutput isn't used in catch
+      toast.error(`Script execution error: ${errorMsg}`);
+    } finally {
+      setIsScriptRunning(false);
+    }
+  }, [
+    isPyodideReady,
+    pythonFile,
+    pyFileContent,
+    selectedDataFiles,
+    loadFilesToFs,
+    setGlobalVariable,
+    runPyodideScript,
+    readFileFromFs,
+    listDirFs,
+  ]);
+
+  const handleUploadOutput = useCallback(async () => {
+    if (!isPyodideReady || !pyodideOutputFilePath || !isCodexNodeActive) {
+      toast.error(
+        "Cannot upload: Pyodide not ready, no output file, or Codex inactive."
+      );
+      return;
+    }
+    const outputFileName =
+      pyodideOutputFilePath.split("/").pop() || `py_output_${Date.now()}.txt`;
+    toast.info(`Preparing to upload ${outputFileName}...`);
+    try {
+      const fileContentUint8Array = readFileFromFs(
+        pyodideOutputFilePath,
+        "binary"
+      ) as Uint8Array;
+      const outputFileBlob = new Blob([fileContentUint8Array], {
+        type: "application/octet-stream",
+      });
+      const outputFile = new File([outputFileBlob], outputFileName, {
+        type: outputFileBlob.type,
+      });
+      await sendOutputFiles([outputFile]);
+    } catch (error) {
+      const errorMsg = error instanceof Error ? error.message : String(error);
+      toast.error(`Error preparing output for upload: ${errorMsg}`);
+    }
+  }, [
+    isPyodideReady,
+    pyodideOutputFilePath,
+    sendOutputFiles,
+    isCodexNodeActive,
+    readFileFromFs,
+  ]);
+
+  const handleModalClose = () => {
+    onOpenChange(false);
+    setPyFileContent("");
+    setPyodideOutput([]);
+    setSelectedDataFiles(null);
+    if (dataFileInputRef.current) dataFileInputRef.current.value = "";
+    setPyodideOutputFilePath(null);
+    setIsScriptRunning(false);
+  };
+
+  // Render logic remains largely the same, using the hook's state and functions
+  // ... (JSX for Dialog, DialogContent, etc.) ...
+  // (The existing JSX for the modal can be used here, just ensure it calls the hook's functions
+  // and uses the hook's state variables like isPyodideReady, pyodideLoadingMessage)
+
+  if (!isOpen) return null;
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleModalClose}>
+      <DialogContent className="sm:max-w-[700px] md:max-w-[900px] lg:max-w-[1100px] h-[90vh] flex flex-col bg-card border-border">
+        <DialogHeader className="border-b border-border pb-3">
+          <DialogTitle className="font-mono text-primary">
+            View & Run: {pythonFile?.name || "Python Script"}
+          </DialogTitle>
+          <DialogDescription className="font-mono text-muted-foreground">
+            View script, select data file(s), run in Pyodide, and upload output.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 flex-grow overflow-hidden min-h-0">
+          <div className="flex flex-col overflow-hidden border border-input rounded-md p-1 bg-background">
+            <h3 className="text-sm font-mono text-center py-1 text-primary/80">
+              Script: {pythonFile?.name || "N/A"}
+            </h3>
+            <ScrollArea className="flex-grow p-1">
+              <pre className="text-xs font-mono whitespace-pre-wrap break-all p-2 text-foreground">
+                {pyFileContent ||
+                  (pythonFile
+                    ? "Loading script content..."
+                    : "No script selected.")}
+              </pre>
+            </ScrollArea>
+          </div>
+
+          <div className="flex flex-col overflow-hidden border border-input rounded-md p-1 bg-background">
+            <h3 className="text-sm font-mono text-center py-1 text-primary/80">
+              Execution Output & Logs
+            </h3>
+            <ScrollArea className="flex-grow p-1 mb-2 text-xs font-mono whitespace-pre-wrap break-all bg-black/80 text-green-400 rounded min-h-[100px]">
+              {!isPyodideReady && pyodideLoadingMessage && (
+                <p className="p-2 text-amber-400">{pyodideLoadingMessage}</p>
+              )}
+              {isPyodideReady &&
+                pyodideOutput.length === 0 &&
+                !isScriptRunning && (
+                  <p className="p-2 text-green-400">
+                    {pyodideLoadingMessage}. Select data file(s) and run script.
+                  </p>
+                )}
+              {pyodideOutput.map((line, index) => (
+                <div
+                  key={index}
+                  className={`p-1 ${
+                    line.startsWith("[stderr]") ||
+                    line.startsWith("Execution Error:") ||
+                    line.toLowerCase().includes("error:")
+                      ? "text-red-400"
+                      : line.toLowerCase().includes("warning:")
+                      ? "text-yellow-400"
+                      : ""
+                  }`}
+                >
+                  {line}
+                </div>
+              ))}
+              {isScriptRunning && (
+                <div className="p-2 text-blue-400 animate-pulse flex items-center gap-2">
+                  <Loader2 size={14} className="animate-spin" /> Script is
+                  running...
+                </div>
+              )}
+              {isOutputUploading && (
+                <p className="p-2 text-blue-400 animate-pulse">
+                  Uploading output: {outputUploadProgress}%
+                </p>
+              )}
+            </ScrollArea>
+          </div>
+        </div>
+
+        <DialogFooter className="mt-2 pt-3 border-t border-border items-center">
+          <div className="flex-grow text-xs text-muted-foreground font-mono mr-auto">
+            {selectedDataFiles
+              ? `${selectedDataFiles.length} data file(s) selected`
+              : "No data files selected"}
+            {pyodideOutputFilePath &&
+              ` | Output: ${pyodideOutputFilePath.split("/").pop()}`}
+          </div>
+          <Button
+            variant="outline"
+            className="font-mono"
+            onClick={() => dataFileInputRef.current?.click()}
+            disabled={!isPyodideReady || isScriptRunning || isOutputUploading}
+          >
+            Choose Data File(s)
+          </Button>
+          <input
+            type="file"
+            ref={dataFileInputRef}
+            className="hidden"
+            multiple
+            onChange={(e) => {
+              setSelectedDataFiles(e.target.files);
+              if (e.target.files && e.target.files.length > 0) {
+                toast.info(`Selected ${e.target.files.length} data file(s).`);
+              } else {
+                toast.info("Data file selection cleared.");
+              }
+              e.target.value = "";
+            }}
+          />
+          <Button
+            variant="default"
+            className="font-mono"
+            onClick={handleRunScript}
+            disabled={
+              !isPyodideReady ||
+              isScriptRunning ||
+              !selectedDataFiles ||
+              selectedDataFiles.length === 0 ||
+              !pyFileContent ||
+              isOutputUploading
+            }
+          >
+            {isScriptRunning ? (
+              <Loader2 size={16} className="animate-spin mr-2" />
+            ) : null}
+            {isScriptRunning ? "Running..." : "Run Script"}
+          </Button>
+          <Button
+            variant="secondary"
+            className="font-mono"
+            onClick={handleUploadOutput}
+            disabled={
+              !isPyodideReady ||
+              isScriptRunning ||
+              !pyodideOutputFilePath ||
+              !isCodexNodeActive ||
+              isOutputUploading
+            }
+          >
+            {isOutputUploading ? (
+              <Loader2 size={16} className="animate-spin mr-2" />
+            ) : null}
+            {isOutputUploading
+              ? `Uploading ${outputUploadProgress}%...`
+              : "Upload Output"}
+          </Button>
+          <DialogClose asChild>
+            <Button variant="outline" className="font-mono">
+              Close
+            </Button>
+          </DialogClose>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/hooks/usePyodide.ts
+++ b/hooks/usePyodide.ts
@@ -1,0 +1,203 @@
+// hooks/usePyodide.ts
+import { useState, useCallback } from "react";
+import { toast } from "sonner";
+import type { PyodideInterface } from "pyodide";
+
+// Add declaration for loadPyodide on Window interface
+declare global {
+  interface Window {
+    loadPyodide: (options: { indexURL: string }) => Promise<PyodideInterface>;
+  }
+}
+
+// Keep these at the module level to ensure singleton-like behavior for the instance
+let pyodideInstance: PyodideInterface | null = null;
+let pyodideLoadingPromise: Promise<PyodideInterface> | null = null;
+
+export interface PyodideFile {
+  name: string;
+  content: Uint8Array; // File content as bytes
+}
+
+export function usePyodide() {
+  const [pyodide, setPyodide] = useState<PyodideInterface | null>(
+    pyodideInstance
+  );
+  const [isPyodideReady, setIsPyodideReady] = useState(!!pyodideInstance);
+  const [pyodideLoadingMessage, setPyodideLoadingMessage] = useState<
+    string | null
+  >(pyodideInstance ? "Pyodide is ready." : "Pyodide loading not yet started.");
+
+  const ensurePyodideLoaded = useCallback(async () => {
+    if (pyodideInstance) {
+      if (pyodide !== pyodideInstance) setPyodide(pyodideInstance); // Ensure state sync
+      if (!isPyodideReady) setIsPyodideReady(true);
+      if (pyodideLoadingMessage !== "Pyodide is ready.")
+        setPyodideLoadingMessage("Pyodide is ready.");
+      return pyodideInstance;
+    }
+    if (pyodideLoadingPromise) {
+      setPyodideLoadingMessage("Pyodide is currently loading...");
+      await pyodideLoadingPromise;
+      setPyodide(pyodideInstance);
+      setIsPyodideReady(true);
+      setPyodideLoadingMessage("Pyodide is ready.");
+      return pyodideInstance;
+    }
+
+    setPyodideLoadingMessage("Loading Pyodide runtime...");
+    console.log("usePyodide: Attempting to load Pyodide...");
+
+    const loadScript = (): Promise<void> =>
+      new Promise((resolve, reject) => {
+        if (typeof window.loadPyodide === "function") return resolve();
+        setPyodideLoadingMessage("Loading Pyodide script from CDN...");
+        const script = document.createElement("script");
+        script.src = "https://cdn.jsdelivr.net/pyodide/v0.25.1/full/pyodide.js";
+        script.async = true;
+        script.onload = () => {
+          console.log("usePyodide: Pyodide script loaded.");
+          resolve();
+        };
+        script.onerror = (err) => {
+          console.error("usePyodide: Failed to load Pyodide script.", err);
+          setPyodideLoadingMessage(
+            "Failed to load Pyodide script. Check network or adblockers."
+          );
+          reject(new Error("Failed to load Pyodide script."));
+        };
+        document.head.appendChild(script);
+      });
+
+    pyodideLoadingPromise = loadScript()
+      .then(() =>
+        window.loadPyodide({
+          indexURL: "https://cdn.jsdelivr.net/pyodide/v0.25.1/full/",
+        })
+      )
+      .then((instance) => {
+        pyodideInstance = instance;
+        setPyodide(instance);
+        setIsPyodideReady(true);
+        setPyodideLoadingMessage("Pyodide loaded successfully.");
+        console.log("usePyodide: Pyodide loaded successfully");
+        pyodideLoadingPromise = null;
+        return instance;
+      })
+      .catch((error) => {
+        console.error("usePyodide: Failed to load Pyodide:", error);
+        setPyodideLoadingMessage(`Error loading Pyodide: ${error.message}`);
+        setIsPyodideReady(false);
+        pyodideLoadingPromise = null;
+        throw error; // Re-throw to allow callers to handle
+      });
+    return pyodideLoadingPromise;
+  }, [pyodide, isPyodideReady, pyodideLoadingMessage]); // Dependencies ensure re-check if state is out of sync
+
+  const loadFilesToFs = useCallback(
+    async (files: PyodideFile[], targetDir: string = "/home") => {
+      if (!pyodide || !isPyodideReady) {
+        toast.error("Pyodide not ready to load files.");
+        throw new Error("Pyodide not ready.");
+      }
+      const loadedPaths: string[] = [];
+      for (const file of files) {
+        const sanitizedName = file.name.replace(/\s+/g, "_");
+        const filePath = `${targetDir}/${sanitizedName}`;
+        // Try to create directory if it doesn't exist
+        try {
+          pyodide.FS.mkdirTree(targetDir);
+        } catch (error) {
+          if (isErrnoError(error) && error.errno === 17) {
+            // Directory already exists, which is fine
+          } else {
+            throw error; // Re-throw if it's a different error
+          }
+        }
+        pyodide.FS.writeFile(filePath, file.content);
+        loadedPaths.push(filePath);
+      }
+      return loadedPaths;
+    },
+    [pyodide, isPyodideReady]
+  );
+
+  const setGlobalVariable = useCallback(
+    (name: string, value: string[]) => {
+      if (!pyodide || !isPyodideReady) {
+        toast.error("Pyodide not ready to set global variable.");
+        throw new Error("Pyodide not ready.");
+      }
+      pyodide.globals.set(name, pyodide.toPy(value));
+    },
+    [pyodide, isPyodideReady]
+  );
+
+  const runPythonAsync = useCallback(
+    async (
+      scriptContent: string,
+      stdoutCallback?: (msg: string) => void,
+      stderrCallback?: (msg: string) => void
+    ) => {
+      if (!pyodide || !isPyodideReady) {
+        toast.error("Pyodide not ready to run script.");
+        throw new Error("Pyodide not ready.");
+      }
+      if (stdoutCallback) pyodide.setStdout({ batched: stdoutCallback });
+      if (stderrCallback) pyodide.setStderr({ batched: stderrCallback });
+
+      await pyodide.loadPackagesFromImports(scriptContent); // Load packages based on script
+      return await pyodide.runPythonAsync(scriptContent);
+    },
+    [pyodide, isPyodideReady]
+  );
+
+  const readFileFromFs = useCallback(
+    (
+      path: string,
+      encoding: "utf8" | "binary" = "utf8"
+    ): string | Uint8Array => {
+      if (!pyodide || !isPyodideReady) {
+        toast.error("Pyodide not ready to read file.");
+        throw new Error("Pyodide not ready.");
+      }
+      const data = pyodide.FS.readFile(path);
+      return encoding === "utf8" ? new TextDecoder().decode(data) : data;
+    },
+    [pyodide, isPyodideReady]
+  );
+
+  const listDirFs = useCallback(
+    (path: string): string[] => {
+      if (!pyodide || !isPyodideReady) {
+        toast.error("Pyodide not ready to list directory.");
+        throw new Error("Pyodide not ready.");
+      }
+      return pyodide.FS.readdir(path);
+    },
+    [pyodide, isPyodideReady]
+  );
+
+  return {
+    pyodide, // The instance, if direct access is needed
+    isPyodideReady,
+    pyodideLoadingMessage,
+    ensurePyodideLoaded,
+    loadFilesToFs,
+    setGlobalVariable,
+    runPythonAsync,
+    readFileFromFs,
+    listDirFs,
+  };
+}
+
+/**
+ * Define the FS.ErrnoError type explicitly since it is not exported by the 'pyodide' module.
+ */
+interface FSErrnoError extends Error {
+  errno: number;
+}
+
+function isErrnoError(error: unknown): error is FSErrnoError {
+  return typeof error === "object" && error !== null && "errno" in error;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "15.2.1",
+        "pyodide": "^0.27.6",
         "tailwindcss": "^4",
         "typescript": "^5"
       }
@@ -10128,6 +10129,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/pyodide": {
+      "version": "0.27.6",
+      "resolved": "https://registry.npmjs.org/pyodide/-/pyodide-0.27.6.tgz",
+      "integrity": "sha512-ahiSHHs6iFKl2f8aO1wALINAlMNDLAtb44xCI87GQyH2tLDk8F8VWip3u1ZNIyglGSCYAOSFzWKwS1f9gBFVdg==",
+      "dev": true,
+      "dependencies": {
+        "ws": "^8.5.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/qs": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "15.2.1",
+    "pyodide": "^0.27.6",
     "tailwindcss": "^4",
     "typescript": "^5"
   }

--- a/pages/api/codex/[...path].ts
+++ b/pages/api/codex/[...path].ts
@@ -36,13 +36,14 @@ export default async function handler(
     });
 
     // Copy relevant headers from the original request
-    ["accept", "content-length", "content-disposition"].forEach((header) => {
-      const value = req.headers[header];
-      if (value) {
-        headers.set(header, value.toString());
+    ["accept", "content-type", "content-length", "content-disposition"].forEach(
+      (header) => {
+        const value = req.headers[header];
+        if (value) {
+          headers.set(header, value.toString());
+        }
       }
-    });
-    headers.set("content-type", "text/plain");
+    );
 
     // Get the raw body if needed
     let body: Buffer | undefined;
@@ -72,11 +73,9 @@ export default async function handler(
     res.send(Buffer.from(buffer));
   } catch (error) {
     console.error("Error in Codex API proxy:", error);
-    res
-      .status(500)
-      .json({
-        error: "Internal Server Error",
-        details: error instanceof Error ? error.message : String(error),
-      });
+    res.status(500).json({
+      error: "Internal Server Error",
+      details: error instanceof Error ? error.message : String(error),
+    });
   }
 }

--- a/pages/api/codex/[...path].ts
+++ b/pages/api/codex/[...path].ts
@@ -1,9 +1,9 @@
-import { NextApiRequest, NextApiResponse } from 'next';
-import getRawBody from 'raw-body';
+import { NextApiRequest, NextApiResponse } from "next";
+import getRawBody from "raw-body";
 
-const CODEX_API_BASE = 'https://api.demo.codex.storage/fileshareapp/api/codex';
-const CODEX_USERNAME = 'codex';
-const CODEX_PASSWORD = 'iOpcciMDt2xCJnPrlJ86AaBOrbTzFH';
+const CODEX_API_BASE = "https://api.demo.codex.storage/fileshareapp/api/codex";
+const CODEX_USERNAME = "codex";
+const CODEX_PASSWORD = "iOpcciMDt2xCJnPrlJ86AaBOrbTzFH";
 
 export const config = {
   api: {
@@ -11,42 +11,48 @@ export const config = {
   },
 };
 
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
   try {
     // Get the path from the URL
     const { path } = req.query;
-    const apiPath = Array.isArray(path) ? path.join('/') : path;
+    const apiPath = Array.isArray(path) ? path.join("/") : path;
 
     // Construct the target URL
     const targetUrl = `${CODEX_API_BASE}/${apiPath}`;
-    console.log('Proxying request to:', targetUrl);
+    console.log("Proxying request to:", targetUrl);
 
     // Create Basic Auth header
-    const base64Credentials = Buffer.from(`${CODEX_USERNAME}:${CODEX_PASSWORD}`).toString('base64');
+    const base64Credentials = Buffer.from(
+      `${CODEX_USERNAME}:${CODEX_PASSWORD}`
+    ).toString("base64");
 
     // Prepare headers
     const headers = new Headers({
-      'Authorization': `Basic ${base64Credentials}`,
-      'Host': new URL(CODEX_API_BASE).host,
+      Authorization: `Basic ${base64Credentials}`,
+      Host: new URL(CODEX_API_BASE).host,
     });
 
     // Copy relevant headers from the original request
-    ['accept', 'content-type', 'content-length', 'content-disposition'].forEach(header => {
+    ["accept", "content-length", "content-disposition"].forEach((header) => {
       const value = req.headers[header];
       if (value) {
         headers.set(header, value.toString());
       }
     });
+    headers.set("content-type", "text/plain");
 
     // Get the raw body if needed
     let body: Buffer | undefined;
-    if (req.method !== 'GET' && req.method !== 'HEAD') {
+    if (req.method !== "GET" && req.method !== "HEAD") {
       body = await getRawBody(req);
     }
 
     // Forward the request to the Codex API
     const response = await fetch(targetUrl, {
-      method: req.method || 'GET',
+      method: req.method || "GET",
       headers,
       body,
     });
@@ -65,7 +71,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const buffer = await response.arrayBuffer();
     res.send(Buffer.from(buffer));
   } catch (error) {
-    console.error('Error in Codex API proxy:', error);
-    res.status(500).json({ error: 'Internal Server Error', details: error instanceof Error ? error.message : String(error) });
+    console.error("Error in Codex API proxy:", error);
+    res
+      .status(500)
+      .json({
+        error: "Internal Server Error",
+        details: error instanceof Error ? error.message : String(error),
+      });
   }
-} 
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,36 +1,82 @@
-// pages/index.tsx (lean entry)
+// pages/index.tsx
 import MainLayout from "@/components/layout/MainLayout";
 import { FileUpload } from "@/components/files/FileUpload";
 import { FileList } from "@/components/files/FileList";
 import WakuDebugConsole from "@/components/debug-consoles/WakuDebugConsole";
 import CodexDebugConsole from "@/components/debug-consoles/CodexDebugConsole";
 import TacoDebugConsole from "@/components/debug-consoles/TacoDebugConsole";
-// Uncomment if want to add this component into the index page
-// import NodeInfo from "@/components/codex/NodeInfo";
 import Head from "next/head";
+import { useState, useCallback } from "react"; // Added useCallback
+import { FileItem } from "@/types/files";
+import PyodideRunnerModal from "@/components/pyodide/PyodideRunnerModal";
+import { toast } from "sonner"; // For potential direct toasts
 
-function Home() {
+export default function Home() {
+  const [isPyodideModalOpen, setIsPyodideModalOpen] = useState(false);
+  const [selectedPyFileForModal, setSelectedPyFileForModal] =
+    useState<FileItem | null>(null);
+  const [processingPyFileId, setProcessingPyFileId] = useState<string | null>(
+    null
+  );
+
+  const handleViewPyFileRequest = useCallback((file: FileItem) => {
+    if (!file.fileId) {
+      toast.error("Cannot view script: File ID is missing.");
+      return;
+    }
+    // It's good practice to ensure Pyodide script itself is loaded before modal fully commits
+    // The modal now handles its own Pyodide loading internally based on isOpen.
+    setProcessingPyFileId(file.id.toString()); // Show loading on FileRow
+    setSelectedPyFileForModal(file);
+    setIsPyodideModalOpen(true);
+    // processingPyFileId will be cleared when modal closes or content is ready.
+  }, []);
+
+  const handleModalOpenChange = useCallback((isOpen: boolean) => {
+    setIsPyodideModalOpen(isOpen);
+    if (!isOpen) {
+      setSelectedPyFileForModal(null);
+      setProcessingPyFileId(null); // Clear processing state when modal is closed
+    }
+  }, []);
+
   return (
     <>
       <Head>
         <title>CypherShare</title>
+        <meta
+          name="description"
+          content="Simple filesharing using Codex, Waku, TACo, and Pyodide"
+        />
+        {/* Add other meta tags from your old index.tsx if desired */}
       </Head>
       <MainLayout>
         <div className="container max-w-5xl py-8 mx-auto">
+          {/* NodeInfo is available as a component if you want to uncomment it:
           <div className="space-y-4 mb-6">
-            {/* <NodeInfo /> */}
+             <NodeInfo />
           </div>
+          */}
           <FileUpload />
           <div className="mt-6">
-            <FileList />
+            <FileList
+              onViewPyFile={handleViewPyFileRequest}
+              processingPyFileId={processingPyFileId}
+            />
           </div>
           <WakuDebugConsole />
           <CodexDebugConsole />
           <TacoDebugConsole />
         </div>
       </MainLayout>
+      {isPyodideModalOpen &&
+        selectedPyFileForModal && ( // Conditionally render to ensure props are set
+          <PyodideRunnerModal
+            isOpen={isPyodideModalOpen}
+            onOpenChange={handleModalOpenChange}
+            pythonFile={selectedPyFileForModal}
+          />
+        )}
     </>
   );
 }
-
-export default Home;


### PR DESCRIPTION
this change lets user send .py files - if received, they can be read with a separate button, and executed - they are compiled and run with pyodide into the browser, by selecting files from local storage - of course, if that make sense with the received script. 

output can be uploaded back to cyphershare.

adapted from @interestIngc 's hackathon work during ethglobal Prague; great work, idea, and quick implementation

e.g. script

```

# your_script.py 
import os

try:
    # This global variable is set by JavaScript
    # It's a list of paths like ['/home/data1_txt', '/home/another_file_csv']
    files_to_process = list(SELECTED_DATA_FILES) 
    if not files_to_process:
        print("! Python Error: SELECTED_DATA_FILES list is empty. No files to process.")
        exit()
    print(f"[Python] Received files to process: {files_to_process}")
except NameError:
    print("! Python Error: Global variable 'SELECTED_DATA_FILES' not found.")
    exit()
except Exception as e:
    print(f"! Python Error: Could not access SELECTED_DATA_FILES: {e}")
    exit()

summary_lines = []

for file_path_in_pyodide in files_to_process:
    original_filename = os.path.basename(file_path_in_pyodide) # Get just the filename
    print(f"\n--- Processing {original_filename} (from {file_path_in_pyodide}) ---")
    try:
        if not os.path.exists(file_path_in_pyodide):
            print(f"  ! Error: File {file_path_in_pyodide} does not exist in Pyodide FS.")
            summary_lines.append(f"File: {original_filename}, Error: Not found in Pyodide FS at expected path.")
            continue

        with open(file_path_in_pyodide, 'r', encoding='utf-8') as f_in:
            content = f_in.read()
            content_length = len(content)
            print(f"  Content length: {content_length} characters.")
            # Add your actual processing logic here
            summary_lines.append(f"File: {original_filename}, Length: {content_length}")

    except Exception as e:
        print(f"  ! Error processing {original_filename}: {e}")
        summary_lines.append(f"File: {original_filename}, Error: {e}")

# Example: Create an output file
output_file_path = '/home/script_output_summary.txt'
try:
    with open(output_file_path, 'w', encoding='utf-8') as f_out:
        f_out.write("Script Processing Summary:\n")
        for line in summary_lines:
            f_out.write(line + "\n")
    print(f"\nSummary of processing written to {output_file_path} in Pyodide FS.")
except Exception as e:
    print(f"! Python Error: Could not write output file {output_file_path}: {e}")

print("[Python] Script execution finished.")

```